### PR TITLE
Expose metrics for Airbyte connections and jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [v1.0.0](https://github.com/virtualtam/airbyte_exporter/releases/tag/v1.0.0) - 2023-05-17
+
+Initial release.
+
+### Added
+
+- Setup exporter repository
+- Setup continuous integration with Github Actions
+- Publish Docker images for the `main` branch and tags to `ghcr.io`
+- Gather Airbyte metrics by querying its PostgreSQL database

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 ## Metrics exposed
 ### Counters
 - `airbyte_connections_total{destination_connector, source_connector, status}`
-- `airbyte_jobs_completed_total{destination_connector, source_connector, status}`
+- `airbyte_jobs_completed_total{destination_connector, source_connector, type, status}`
 
 ### Gauges
-- `airbyte_jobs_pending{destination_connector, source_connector}`
-- `airbyte_jobs_running{destination_connector, source_connector}`
+- `airbyte_jobs_pending{destination_connector, source_connector, type}`
+- `airbyte_jobs_running{destination_connector, source_connector, type}`
 
 ## Change Log
 See [CHANGELOG](./CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 
 ## Metrics exposed
 ### Counters
-- `airbyte_connections_total{source, status}`
-- `airbyte_jobs_completed_total{source, status}`
+- `airbyte_connections_total{destination_connector, source_connector, status}`
+- `airbyte_jobs_completed_total{destination_connector, source_connector, status}`
 
 ### Gauges
-- `airbyte_jobs_pending{source}`
-- `airbyte_jobs_running{source}`
+- `airbyte_jobs_pending{destination_connector, source_connector}`
+- `airbyte_jobs_running{destination_connector, source_connector}`
 
 ## Change Log
 See [CHANGELOG](./CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 <img src="https://github.com/virtualtam/airbyte_exporter/actions/workflows/docker.yaml/badge.svg?branch=main" alt="Docker image workflow status">
 
 ## Metrics exposed
+### Counters
+- `airbyte_jobs_completed_total{source, status}`
+
 ### Gauges
 - `airbyte_jobs_pending{source}`
 - `airbyte_jobs_running{source}`

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 <img src="https://github.com/virtualtam/airbyte_exporter/actions/workflows/ci.yaml/badge.svg?branch=main" alt="Continuous integration workflow status">
 <img src="https://github.com/virtualtam/airbyte_exporter/actions/workflows/docker.yaml/badge.svg?branch=main" alt="Docker image workflow status">
 
+## Metrics exposed
+### Gauges
+- `airbyte_jobs_pending{source}`
+- `airbyte_jobs_running{source}`
+
 ## Change Log
 See [CHANGELOG](./CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 ## Metrics exposed
 ### Counters
+- `airbyte_connections_total{source, status}`
 - `airbyte_jobs_completed_total{source, status}`
 
 ### Gauges

--- a/README.md
+++ b/README.md
@@ -12,6 +12,158 @@
 - `airbyte_jobs_pending{destination_connector, source_connector, type}`
 - `airbyte_jobs_running{destination_connector, source_connector, type}`
 
+## Configuration
+`airbyte_exporter` can be configured via:
+
+- environment variables, e.g. `AIRBYTE_EXPORTER_DB_PASSWORD=p455w0rd`
+- a configuration file
+- POSIX flags, e.g. `--db-password p455w0rd`
+
+Available flags can be listed using the program's help:
+
+```shell
+$ ./airbyte_exporter --help
+
+Airbyte Exporter
+
+Usage:
+  airbyte_exporter [flags]
+
+Flags:
+      --db-addr string       Database address (host:port) (default "localhost:5432")
+      --db-name string       Database name (default "airbyte")
+      --db-password string   Database password (default "airbyte_exporter")
+      --db-sslmode string    Database sslmode (default "disable")
+      --db-user string       Database user (default "airbyte_exporter")
+  -h, --help                 help for airbyte_exporter
+      --listen-addr string   Listen to this address (host:port) (default "0.0.0.0:8080")
+      --log-level string     Log level (trace, debug, info, warn, error, fatal, panic) (default "info")
+```
+
+### Example configuration file
+
+The exporter will look for configuration files located under:
+    - `/etc/airbyte_exporter.yaml`
+    - `~/.config/airbyte_exporter.yaml`
+
+```yaml
+# Global exporter options
+listen-addr: 0.0.0.0:8080
+log-level: info
+
+# Airbyte database options
+db-addr: "postgresql:5432"
+db-name: airbyte
+db-password: "ch4ng3m3!"
+db-sslmode: require
+```
+
+### PostgreSQL user
+The exporter needs to be able to connect to the Airbyte database, and have read-only access
+to Airbyte database tables.
+
+The following commands are provided as an example; see PostgreSQL's documentation for
+further information:
+
+- [`CREATE ROLE`](https://www.postgresql.org/docs/current/sql-createrole.html)
+- [`GRANT`](https://www.postgresql.org/docs/current/sql-grant.html)
+- [Predefined roles](https://www.postgresql.org/docs/current/predefined-roles.html#PREDEFINED-ROLES-TABLE)
+
+Connect to the `airbyte` database:
+
+```shell
+# psql -h <host> -p <port> -U <admin_user> <database>
+$ psql -h 127.0.0.1 -p 5432 -U postgres airbyte
+```
+
+Create the user:
+
+```sql
+CREATE ROLE airbyte_exporter WITH LOGIN ENCRYPTED PASSWORD 'SomeStrongPassword';
+```
+
+For PostgreSQL **version 14 and above**, grant read-only privileges with:
+
+```sql
+GRANT pg_read_all_data TO airbyte_exporter;
+```
+
+For PostgreSQL **version 13 and below**, grant read-only privileges on current and newly created tables with:
+
+```sql
+-- Current tables
+GRANT CONNECT ON DATABASE YourDatabaseName TO airbyte_exporter;
+GRANT USAGE ON SCHEMA public TO airbyte_exporter;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO airbyte_exporter;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO airbyte_exporter;
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+
+-- Newly created tables
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO airbyte_exporter;
+```
+
+## Running
+See [`airbyte_exporter` container packages](https://github.com/virtualtam/airbyte_exporter/pkgs/container/airbyte_exporter)
+for a list of available Docker image tags.
+
+### Docker
+
+Pull the Docker image:
+
+```shell
+$ docker pull ghcr.io/virtualtam/airbyte_exporter:latest
+```
+
+Run the exporter:
+
+```shell
+$ docker run \
+    --name airbyte-exporter \
+    --rm \
+    -e AIRBYTE_EXPORTER_DB_HOST=postgresql \
+    -e AIRBYTE_EXPORTER_DB_PASSWORD=ch4ng3m3 \
+    -p 8080:8080
+    ghcr.io/virtualtam/airbyte_exporter:latest
+```
+
+### Helm Chart for Kubernetes
+
+See instructions on Artifact Hub for [virtualtam/prometheus-airbyte-exporter](https://artifacthub.io/packages/helm/virtualtam/prometheus-airbyte-exporter).
+
+## Building
+
+Get the sources:
+
+```shell
+$ git clone https://github.com/virtualtam/airbyte_exporter.git
+$ cd ccache_exporter
+```
+
+Run linters:
+
+```shell
+$ make lint
+```
+
+Build the parser and exporter:
+
+```shell
+$ make build
+```
+
+Build platform-specific binaries with [Promu](https://github.com/prometheus/promu):
+
+```shell
+$ promu crossbuild
+```
+
+Build and archive platform-specific binaries:
+
+```shell
+$ promu crossbuild
+$ promu crossbuild tarballs
+```
+
 ## Change Log
 See [CHANGELOG](./CHANGELOG.md)
 

--- a/cmd/airbyte_exporter/collector.go
+++ b/cmd/airbyte_exporter/collector.go
@@ -36,26 +36,26 @@ func NewCollector(airbyteService *airbyte.Service) *collector {
 		connections: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "connections_total"),
 			"Connections (total)",
-			[]string{"source", "status"},
+			[]string{"destination_connector", "source_connector", "status"},
 			nil,
 		),
 
 		jobsCompleted: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "jobs_completed_total"),
 			"Completed jobs (total)",
-			[]string{"source", "status"},
+			[]string{"destination_connector", "source_connector", "status"},
 			nil,
 		),
 		jobsPending: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "jobs_pending"),
 			"Pending jobs",
-			[]string{"source"},
+			[]string{"destination_connector", "source_connector"},
 			nil,
 		),
 		jobsRunning: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "jobs_running"),
 			"Running jobs",
-			[]string{"source"},
+			[]string{"destination_connector", "source_connector"},
 			nil,
 		),
 	}
@@ -83,7 +83,8 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 			c.connections,
 			prometheus.CounterValue,
 			float64(connections.Count),
-			connections.Source,
+			connections.DestinationConnector,
+			connections.SourceConnector,
 			connections.Status,
 		)
 	}
@@ -93,17 +94,30 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 			c.jobsCompleted,
 			prometheus.CounterValue,
 			float64(jobsCompleted.Count),
-			jobsCompleted.Source,
+			jobsCompleted.DestinationConnector,
+			jobsCompleted.SourceConnector,
 			jobsCompleted.Status,
 		)
 	}
 
 	// Gauges
 	for _, jobsPending := range metrics.JobsPending {
-		ch <- prometheus.MustNewConstMetric(c.jobsPending, prometheus.GaugeValue, float64(jobsPending.Count), jobsPending.Source)
+		ch <- prometheus.MustNewConstMetric(
+			c.jobsPending,
+			prometheus.GaugeValue,
+			float64(jobsPending.Count),
+			jobsPending.DestinationConnector,
+			jobsPending.SourceConnector,
+		)
 	}
 
 	for _, jobsRunning := range metrics.JobsRunning {
-		ch <- prometheus.MustNewConstMetric(c.jobsRunning, prometheus.GaugeValue, float64(jobsRunning.Count), jobsRunning.Source)
+		ch <- prometheus.MustNewConstMetric(
+			c.jobsRunning,
+			prometheus.GaugeValue,
+			float64(jobsRunning.Count),
+			jobsRunning.DestinationConnector,
+			jobsRunning.SourceConnector,
+		)
 	}
 }

--- a/cmd/airbyte_exporter/collector.go
+++ b/cmd/airbyte_exporter/collector.go
@@ -43,19 +43,19 @@ func NewCollector(airbyteService *airbyte.Service) *collector {
 		jobsCompleted: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "jobs_completed_total"),
 			"Completed jobs (total)",
-			[]string{"destination_connector", "source_connector", "status"},
+			[]string{"destination_connector", "source_connector", "type", "status"},
 			nil,
 		),
 		jobsPending: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "jobs_pending"),
 			"Pending jobs",
-			[]string{"destination_connector", "source_connector"},
+			[]string{"destination_connector", "source_connector", "type"},
 			nil,
 		),
 		jobsRunning: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "jobs_running"),
 			"Running jobs",
-			[]string{"destination_connector", "source_connector"},
+			[]string{"destination_connector", "source_connector", "type"},
 			nil,
 		),
 	}
@@ -96,6 +96,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 			float64(jobsCompleted.Count),
 			jobsCompleted.DestinationConnector,
 			jobsCompleted.SourceConnector,
+			jobsCompleted.Type,
 			jobsCompleted.Status,
 		)
 	}
@@ -108,6 +109,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 			float64(jobsPending.Count),
 			jobsPending.DestinationConnector,
 			jobsPending.SourceConnector,
+			jobsPending.Type,
 		)
 	}
 
@@ -118,6 +120,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 			float64(jobsRunning.Count),
 			jobsRunning.DestinationConnector,
 			jobsRunning.SourceConnector,
+			jobsRunning.Type,
 		)
 	}
 }

--- a/internal/airbyte/metrics.go
+++ b/internal/airbyte/metrics.go
@@ -7,17 +7,18 @@ package airbyte
 // Metrics represents available Airbyte metrics.
 type Metrics struct {
 	// Airbyte connections
-	Connections []CountBySourceAndStatus
+	Connections []ItemCount
 
 	// Airbyte jobs
-	JobsCompleted []CountBySourceAndStatus
-	JobsPending   []CountBySourceAndStatus
-	JobsRunning   []CountBySourceAndStatus
+	JobsCompleted []ItemCount
+	JobsPending   []ItemCount
+	JobsRunning   []ItemCount
 }
 
-// CountBySourceAndStatus holds a count of Airbyte items, grouped by source name and status.
-type CountBySourceAndStatus struct {
-	Source string `db:"source"`
-	Status string `db:"status"`
-	Count  uint   `db:"count"`
+// ItemCount holds a count of Airbyte items, grouped by destination connector, source connector and status.
+type ItemCount struct {
+	DestinationConnector string `db:"destination"`
+	SourceConnector      string `db:"source"`
+	Status               string `db:"status"`
+	Count                uint   `db:"count"`
 }

--- a/internal/airbyte/metrics.go
+++ b/internal/airbyte/metrics.go
@@ -7,18 +7,27 @@ package airbyte
 // Metrics represents available Airbyte metrics.
 type Metrics struct {
 	// Airbyte connections
-	Connections []ItemCount
+	Connections []ConnectionCount
 
 	// Airbyte jobs
-	JobsCompleted []ItemCount
-	JobsPending   []ItemCount
-	JobsRunning   []ItemCount
+	JobsCompleted []JobCount
+	JobsPending   []JobCount
+	JobsRunning   []JobCount
 }
 
-// ItemCount holds a count of Airbyte items, grouped by destination connector, source connector and status.
-type ItemCount struct {
+// ConnectionCount holds a count of Airbyte connections, grouped by destination connector, source connector and status.
+type ConnectionCount struct {
 	DestinationConnector string `db:"destination"`
 	SourceConnector      string `db:"source"`
+	Status               string `db:"status"`
+	Count                uint   `db:"count"`
+}
+
+// JobCount holds a count of Airbyte jobs, grouped by destination connector, source connector, type and status.
+type JobCount struct {
+	DestinationConnector string `db:"destination"`
+	SourceConnector      string `db:"source"`
+	Type                 string `db:"config_type"`
 	Status               string `db:"status"`
 	Count                uint   `db:"count"`
 }

--- a/internal/airbyte/metrics.go
+++ b/internal/airbyte/metrics.go
@@ -6,14 +6,17 @@ package airbyte
 
 // Metrics represents available Airbyte metrics.
 type Metrics struct {
+	// Airbyte connections
+	Connections []CountBySourceAndStatus
+
 	// Airbyte jobs
-	JobsCompleted []JobStatusCount
-	JobsPending   []JobStatusCount
-	JobsRunning   []JobStatusCount
+	JobsCompleted []CountBySourceAndStatus
+	JobsPending   []CountBySourceAndStatus
+	JobsRunning   []CountBySourceAndStatus
 }
 
-// JobStatusCount holds a count of Airbyte jobs, grouped by source name and status.
-type JobStatusCount struct {
+// CountBySourceAndStatus holds a count of Airbyte items, grouped by source name and status.
+type CountBySourceAndStatus struct {
 	Source string `db:"source"`
 	Status string `db:"status"`
 	Count  uint   `db:"count"`

--- a/internal/airbyte/metrics.go
+++ b/internal/airbyte/metrics.go
@@ -7,8 +7,9 @@ package airbyte
 // Metrics represents available Airbyte metrics.
 type Metrics struct {
 	// Airbyte jobs
-	JobsPending []JobStatusCount
-	JobsRunning []JobStatusCount
+	JobsCompleted []JobStatusCount
+	JobsPending   []JobStatusCount
+	JobsRunning   []JobStatusCount
 }
 
 // JobStatusCount holds a count of Airbyte jobs, grouped by source name and status.

--- a/internal/airbyte/metrics.go
+++ b/internal/airbyte/metrics.go
@@ -7,7 +7,13 @@ package airbyte
 // Metrics represents available Airbyte metrics.
 type Metrics struct {
 	// Airbyte jobs
-	JobPending       uint
-	JobRunning       uint
-	JobRunningOrphan uint
+	JobsPending []JobStatusCount
+	JobsRunning []JobStatusCount
+}
+
+// JobStatusCount holds a count of Airbyte jobs, grouped by source name and status.
+type JobStatusCount struct {
+	Source string `db:"source"`
+	Status string `db:"status"`
+	Count  uint   `db:"count"`
 }

--- a/internal/airbyte/service.go
+++ b/internal/airbyte/service.go
@@ -18,23 +18,18 @@ func NewService(r *Repository) *Service {
 
 // GatherMetrics gathers and returns metrics from Airbyte's PostgreSQL database.
 func (s *Service) GatherMetrics() (*Metrics, error) {
-	jobPending, err := s.r.JobPending()
+	jobsPending, err := s.r.JobsPendingBySourceName()
 	if err != nil {
 		return &Metrics{}, err
 	}
 
-	jobRunning, err := s.r.JobRunning()
-	if err != nil {
-		return &Metrics{}, err
-	}
-	jobRunningOrphan, err := s.r.JobRunningOrphan()
+	jobsRunning, err := s.r.JobsRunningBySourceName()
 	if err != nil {
 		return &Metrics{}, err
 	}
 
 	return &Metrics{
-		JobPending:       jobPending,
-		JobRunning:       jobRunning,
-		JobRunningOrphan: jobRunningOrphan,
+		JobsPending: jobsPending,
+		JobsRunning: jobsRunning,
 	}, nil
 }

--- a/internal/airbyte/service.go
+++ b/internal/airbyte/service.go
@@ -18,6 +18,11 @@ func NewService(r *Repository) *Service {
 
 // GatherMetrics gathers and returns metrics from Airbyte's PostgreSQL database.
 func (s *Service) GatherMetrics() (*Metrics, error) {
+	jobsCompleted, err := s.r.JobsCompletedBySourceName()
+	if err != nil {
+		return &Metrics{}, err
+	}
+
 	jobsPending, err := s.r.JobsPendingBySourceName()
 	if err != nil {
 		return &Metrics{}, err
@@ -29,7 +34,8 @@ func (s *Service) GatherMetrics() (*Metrics, error) {
 	}
 
 	return &Metrics{
-		JobsPending: jobsPending,
-		JobsRunning: jobsRunning,
+		JobsCompleted: jobsCompleted,
+		JobsPending:   jobsPending,
+		JobsRunning:   jobsRunning,
 	}, nil
 }

--- a/internal/airbyte/service.go
+++ b/internal/airbyte/service.go
@@ -18,6 +18,11 @@ func NewService(r *Repository) *Service {
 
 // GatherMetrics gathers and returns metrics from Airbyte's PostgreSQL database.
 func (s *Service) GatherMetrics() (*Metrics, error) {
+	connections, err := s.r.ConnectionsBySourceName()
+	if err != nil {
+		return &Metrics{}, err
+	}
+
 	jobsCompleted, err := s.r.JobsCompletedBySourceName()
 	if err != nil {
 		return &Metrics{}, err
@@ -34,6 +39,7 @@ func (s *Service) GatherMetrics() (*Metrics, error) {
 	}
 
 	return &Metrics{
+		Connections:   connections,
 		JobsCompleted: jobsCompleted,
 		JobsPending:   jobsPending,
 		JobsRunning:   jobsRunning,

--- a/internal/airbyte/service.go
+++ b/internal/airbyte/service.go
@@ -18,22 +18,22 @@ func NewService(r *Repository) *Service {
 
 // GatherMetrics gathers and returns metrics from Airbyte's PostgreSQL database.
 func (s *Service) GatherMetrics() (*Metrics, error) {
-	connections, err := s.r.ConnectionsBySourceName()
+	connections, err := s.r.ConnectionsCount()
 	if err != nil {
 		return &Metrics{}, err
 	}
 
-	jobsCompleted, err := s.r.JobsCompletedBySourceName()
+	jobsCompleted, err := s.r.JobsCompletedCount()
 	if err != nil {
 		return &Metrics{}, err
 	}
 
-	jobsPending, err := s.r.JobsPendingBySourceName()
+	jobsPending, err := s.r.JobsPendingCount()
 	if err != nil {
 		return &Metrics{}, err
 	}
 
-	jobsRunning, err := s.r.JobsRunningBySourceName()
+	jobsRunning, err := s.r.JobsRunningCount()
 	if err != nil {
 		return &Metrics{}, err
 	}


### PR DESCRIPTION
### Added
- Expose counts for connections, grouped by: destination connector, source connector and status (active, inactive, deprecated)
- Expose counts for pending, running and completed jobs, grouped by: destination connector, source connector, type (sync, discovery, check, etc.) and status
- Document exposed counters and gauges