### PR TITLE
collector: expose an histogram with the age of the last successful sync for connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - Expose source and destination status
+- Expose an histogram for the age of the last successful sync attempt for connections
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,17 @@
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/botify-helm-charts)](https://artifacthub.io/packages/search?repo=botify-helm-charts)
 
 ## Metrics exposed
-### Counters
-- `airbyte_jobs_completed_total{destination_connector, source_connector, type, status}`
 
-### Gauges
-- `airbyte_connections{destination_connector, source_connector, status}`
-- `airbyte_sources{source_connector, tombstone}`
-- `airbyte_destinations{destination_connector, tombstone}`
-- `airbyte_jobs_pending{destination_connector, source_connector, type}`
-- `airbyte_jobs_running{destination_connector, source_connector, type}`
+| Metric                                               | Type      | Labels                                                |
+| ---------------------------------------------------- | --------- | ----------------------------------------------------- |
+| `airbyte_jobs_completed_total`                       | Counter   | destination_connector, source_connector, type, status |
+| `airbyte_connections`                                | Gauge     | destination_connector, source_connector, status       |
+| `airbyte_sources`                                    | Gauge     | source_connector, tombstone                           |
+| `airbyte_destinations`                               | Gauge     | destination_connector, tombstone                      |
+| `airbyte_jobs_pending`                               | Gauge     | destination_connector, source_connector, type         |
+| `airbyte_jobs_running`                               | Gauge     | destination_connector, source_connector, type         |
+| `airbyte_connections_last_successful_sync_age_hours` | Histogram | destination_connector, source_connector               |
+
 
 ## Configuration
 `airbyte_exporter` can be configured via:

--- a/internal/airbyte/metrics.go
+++ b/internal/airbyte/metrics.go
@@ -4,10 +4,17 @@
 
 package airbyte
 
+import (
+	"fmt"
+	"math"
+	"time"
+)
+
 // Metrics represents available Airbyte metrics.
 type Metrics struct {
 	// Airbyte connections
-	Connections []ConnectionCount
+	Connections                       []ConnectionCount
+	ConnectionsLastSuccessfulSyncAges []ConnectionSyncAge
 
 	// Airbyte connectors
 	Sources      []ActorCount
@@ -25,6 +32,19 @@ type ConnectionCount struct {
 	SourceConnector      string `db:"source"`
 	Status               string `db:"status"`
 	Count                uint   `db:"count"`
+}
+
+// ConnectionSyncAge holds the age of the last job attempt for a single Airbyte Connection.
+type ConnectionSyncAge struct {
+	ID                   string  `db:"id"`
+	DestinationConnector string  `db:"destination"`
+	SourceConnector      string  `db:"source"`
+	Hours                float64 `db:"hours"` // no Scanner for time.Duration, storing as a raw string
+}
+
+// Age returns the duration since the last job attempt.
+func (csa *ConnectionSyncAge) Age() (time.Duration, error) {
+	return time.ParseDuration(fmt.Sprintf("%fh", math.Round(csa.Hours)))
 }
 
 // ActorCount holds a count of Airbyte actors, grouped by actor connector and status.

--- a/internal/airbyte/service.go
+++ b/internal/airbyte/service.go
@@ -23,6 +23,11 @@ func (s *Service) GatherMetrics() (*Metrics, error) {
 		return &Metrics{}, err
 	}
 
+	connectionsLastSuccessfulSyncAges, err := s.r.ConnectionsLastSuccessfulSyncAge()
+	if err != nil {
+		return &Metrics{}, err
+	}
+
 	sources, err := s.r.SourcesCount()
 	if err != nil {
 		return &Metrics{}, err
@@ -49,11 +54,12 @@ func (s *Service) GatherMetrics() (*Metrics, error) {
 	}
 
 	return &Metrics{
-		Connections:   connections,
-		Sources:       sources,
-		Destinations:  destinations,
-		JobsCompleted: jobsCompleted,
-		JobsPending:   jobsPending,
-		JobsRunning:   jobsRunning,
+		Connections:                       connections,
+		ConnectionsLastSuccessfulSyncAges: connectionsLastSuccessfulSyncAges,
+		Sources:                           sources,
+		Destinations:                      destinations,
+		JobsCompleted:                     jobsCompleted,
+		JobsPending:                       jobsPending,
+		JobsRunning:                       jobsRunning,
 	}, nil
 }


### PR DESCRIPTION
### Added
- Add histogram `airbyte_connections_last_successful_sync_age_hours` to expose the age of the last successful sync job attempt for Airbyte connections:
    - buckets are grouped by destination and source connector name
    - the age is tracked in hours
    - current buckets are: 6, 12, 18, 24, 48, 72, 168 hours