### PR TITLE
collector: add `schedule_type` dimension for job and connection sync metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@
 
 ## Metrics exposed
 
-| Metric                                               | Type      | Labels                                                |
-| ---------------------------------------------------- | --------- | ----------------------------------------------------- |
-| `airbyte_jobs_completed_total`                       | Counter   | destination_connector, source_connector, type, status |
-| `airbyte_connections`                                | Gauge     | destination_connector, source_connector, status       |
-| `airbyte_sources`                                    | Gauge     | source_connector, tombstone                           |
-| `airbyte_destinations`                               | Gauge     | destination_connector, tombstone                      |
-| `airbyte_jobs_pending`                               | Gauge     | destination_connector, source_connector, type         |
-| `airbyte_jobs_running`                               | Gauge     | destination_connector, source_connector, type         |
-| `airbyte_connections_last_successful_sync_age_hours` | Histogram | destination_connector, source_connector               |
+| Metric                                               | Type      | Labels                                                               |
+| ---------------------------------------------------- | --------- | -------------------------------------------------------------------- |
+| `airbyte_jobs_completed_total`                       | Counter   | destination_connector, source_connector, schedule_type, type, status |
+| `airbyte_connections`                                | Gauge     | destination_connector, source_connector, status                      |
+| `airbyte_sources`                                    | Gauge     | source_connector, tombstone                                          |
+| `airbyte_destinations`                               | Gauge     | destination_connector, tombstone                                     |
+| `airbyte_jobs_pending`                               | Gauge     | destination_connector, source_connector, schedule_type, type         |
+| `airbyte_jobs_running`                               | Gauge     | destination_connector, source_connector, schedule_type, type         |
+| `airbyte_connections_last_successful_sync_age_hours` | Histogram | destination_connector, source_connector, schedule_type               |
 
 
 ## Configuration

--- a/cmd/airbyte_exporter/collector.go
+++ b/cmd/airbyte_exporter/collector.go
@@ -62,19 +62,19 @@ func NewCollector(airbyteService *airbyte.Service) *collector {
 		jobsCompleted: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "jobs_completed_total"),
 			"Completed jobs (total)",
-			[]string{"destination_connector", "source_connector", "type", "status"},
+			[]string{"destination_connector", "source_connector", "schedule_type", "type", "status"},
 			nil,
 		),
 		jobsPending: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "jobs_pending"),
 			"Pending jobs",
-			[]string{"destination_connector", "source_connector", "type"},
+			[]string{"destination_connector", "source_connector", "schedule_type", "type"},
 			nil,
 		),
 		jobsRunning: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "jobs_running"),
 			"Running jobs",
-			[]string{"destination_connector", "source_connector", "type"},
+			[]string{"destination_connector", "source_connector", "schedule_type", "type"},
 			nil,
 		),
 	}
@@ -106,6 +106,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 			float64(jobsCompleted.Count),
 			jobsCompleted.DestinationConnector,
 			jobsCompleted.SourceConnector,
+			jobsCompleted.ScheduleType,
 			jobsCompleted.Type,
 			jobsCompleted.Status,
 		)
@@ -150,6 +151,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 			float64(jobsPending.Count),
 			jobsPending.DestinationConnector,
 			jobsPending.SourceConnector,
+			jobsPending.ScheduleType,
 			jobsPending.Type,
 		)
 	}
@@ -161,6 +163,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 			float64(jobsRunning.Count),
 			jobsRunning.DestinationConnector,
 			jobsRunning.SourceConnector,
+			jobsRunning.ScheduleType,
 			jobsRunning.Type,
 		)
 	}
@@ -173,7 +176,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 			Help:      "Age of the last successful sync job (hours)",
 			Buckets:   []float64{6, 12, 18, 24, 48, 72, 168},
 		},
-		[]string{"destination_connector", "source_connector"},
+		[]string{"destination_connector", "source_connector", "schedule_type"},
 	)
 
 	for _, connectionLastSuccessfulSyncAge := range metrics.ConnectionsLastSuccessfulSyncAges {
@@ -191,6 +194,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 			WithLabelValues(
 				connectionLastSuccessfulSyncAge.DestinationConnector,
 				connectionLastSuccessfulSyncAge.SourceConnector,
+				connectionLastSuccessfulSyncAge.ScheduleType,
 			).
 			Observe(age.Hours())
 	}

--- a/internal/airbyte/metrics.go
+++ b/internal/airbyte/metrics.go
@@ -39,7 +39,8 @@ type ConnectionSyncAge struct {
 	ID                   string  `db:"id"`
 	DestinationConnector string  `db:"destination"`
 	SourceConnector      string  `db:"source"`
-	Hours                float64 `db:"hours"` // no Scanner for time.Duration, storing as a raw string
+	ScheduleType         string  `db:"connection_schedule_type"`
+	Hours                float64 `db:"hours"` // no Scanner for time.Duration, storing as a raw value
 }
 
 // Age returns the duration since the last job attempt.
@@ -58,6 +59,7 @@ type ActorCount struct {
 type JobCount struct {
 	DestinationConnector string `db:"destination"`
 	SourceConnector      string `db:"source"`
+	ScheduleType         string `db:"connection_schedule_type"`
 	Type                 string `db:"config_type"`
 	Status               string `db:"status"`
 	Count                uint   `db:"count"`


### PR DESCRIPTION
### Changed
- Update the following metrics to add the connection's `schedule_type` dimension:
    - `airbyte_jobs_completed_total` counter
    - `airbyte_jobs_pending` gauge
    - `airbyte_jobs_running` gauge
    - `airbyte_connections_last_successful_sync_age_hours` histogram

### Notes
There can be some discrepancies in the `connection` table, where there are several fields used to track how synchronization jobs are scheduled:

- `manual` (bool, non-nullable)
- `schedule_type` (enum, nullable)
- `schedule` (JSONB, nullable)

As `schedule_type` is nullable, and can be `NULL` following an incomplete database migration, we coalesce it with a default value of `manual`.