### PR TITLE
Update README.md, fix example run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Run the exporter:
 $ docker run \
     --name airbyte-exporter \
     --rm \
-    -e AIRBYTE_EXPORTER_DB_HOST=postgresql \
+    -e AIRBYTE_EXPORTER_DB_ADDR="postgres:5432" \
     -e AIRBYTE_EXPORTER_DB_PASSWORD=ch4ng3m3 \
     -p 8080:8080
     ghcr.io/botify-labs/airbyte_exporter:latest


### PR DESCRIPTION
Fix example command in readme.

Not sure if it is interesting to add also an example on how to monitor airbyte deploed via docker compose.

enter the db container
`docker exec -it airbyte-db /bin/bash`

access the pgsql in the db container
`psql -h 127.0.0.1 -p 5432 -U docker airbyte
`

Run airbyte exporter making sure it is connected to the docker airbyte internal network.
`docker run \
    --name airbyte-exporter \
    --rm \
    -e AIRBYTE_EXPORTER_DB_ADDR=airbyte-db:5432 \
    -e AIRBYTE_EXPORTER_DB_PASSWORD=<yourpassword> \
    -p 8090:8080 \
    --network="airbyte_airbyte_internal" \
    ghcr.io/botify-labs/airbyte_exporter:latest
`